### PR TITLE
refactor: lucide-react → react-icons 마이그레이션 (#31)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "@tanstack/react-query": "^5.90.5",
         "axios": "^1.12.2",
         "husky": "^9.1.7",
-        "lucide-react": "^0.548.0",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.9.5",
         "tailwindcss": "^4.1.16",
         "zustand": "^5.0.8"
@@ -5515,15 +5515,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/lucide-react": {
-      "version": "0.548.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.548.0.tgz",
-      "integrity": "sha512-63b16z63jM9yc1MwxajHeuu0FRZFsDtljtDjYm26Kd86UQ5HQzu9ksEtoUUw4RBuewodw/tGFmvipePvRsKeDA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -6143,6 +6134,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "@tanstack/react-query": "^5.90.5",
     "axios": "^1.12.2",
     "husky": "^9.1.7",
-    "lucide-react": "^0.548.0",
     "postcss": "^8.5.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.9.5",
     "tailwindcss": "^4.1.16",
     "zustand": "^5.0.8"

--- a/src/components/icon/CartIcon.tsx
+++ b/src/components/icon/CartIcon.tsx
@@ -1,17 +1,10 @@
-import { ShoppingCart } from 'lucide-react';
-import type { IconProps } from '@/components/types/type';
+import { LuShoppingCart } from 'react-icons/lu';
+import type { IconProps } from '@/components/types';
 
-export function CartIcon({ width, height, color, className, strokeWidth, ...rest }: IconProps) {
+export function CartIcon({ size, color, className }: IconProps) {
   return (
     <>
-      <ShoppingCart
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      />
+      <LuShoppingCart size={size} color={color} className={className} />
     </>
   );
 }

--- a/src/components/icon/HeaderLogoIcon.tsx
+++ b/src/components/icon/HeaderLogoIcon.tsx
@@ -1,5 +1,5 @@
 import LogoImage from '@/asset/logo.svg';
-import type { LogoProps } from '@/components/types/type';
+import type { LogoProps } from '@/components/types';
 
 export function HeaderLogoIcon({ width, height, className }: LogoProps) {
   return (

--- a/src/components/icon/HeaderLogoImgIcon.tsx
+++ b/src/components/icon/HeaderLogoImgIcon.tsx
@@ -1,5 +1,5 @@
 import LogoImgImage from '@/asset/logo-img.svg';
-import type { LogoProps } from '@/components/types/type';
+import type { LogoProps } from '@/components/types';
 
 export function HeaderLogoImgIcon({ width, height, className }: LogoProps) {
   return (

--- a/src/components/icon/HeartIcon.tsx
+++ b/src/components/icon/HeartIcon.tsx
@@ -1,17 +1,10 @@
-import type { IconProps } from '@/components/types/type';
-import { Heart } from 'lucide-react';
+import type { IconProps } from '@/components/types';
+import { GoHeart } from 'react-icons/go';
 
-export function HeartIcon({ width, height, color, className, strokeWidth, ...rest }: IconProps) {
+export function HeartIcon({ size, color, className }: IconProps) {
   return (
     <>
-      <Heart
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      />
+      <GoHeart size={size} color={color} className={className} />
     </>
   );
 }

--- a/src/components/icon/ImageIcon.tsx
+++ b/src/components/icon/ImageIcon.tsx
@@ -1,17 +1,10 @@
-import { ImagePlus } from 'lucide-react';
-import type { IconProps } from '@/components/types/type';
+import { LuImagePlus } from 'react-icons/lu';
+import type { IconProps } from '@/components/types';
 
-export function ImageIcon({ width, height, color, className, strokeWidth, ...rest }: IconProps) {
+export function ImageIcon({ size, color, className }: IconProps) {
   return (
     <>
-      <ImagePlus
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      ></ImagePlus>
+      <LuImagePlus size={size} color={color} className={className}></LuImagePlus>
     </>
   );
 }

--- a/src/components/icon/NavigationIcon.tsx
+++ b/src/components/icon/NavigationIcon.tsx
@@ -1,24 +1,10 @@
-import { Menu } from 'lucide-react';
-import type { IconProps } from '@/components/types/type';
+import { LuMenu } from 'react-icons/lu';
+import type { IconProps } from '@/components/types';
 
-export function NavigationIcon({
-  width,
-  height,
-  color,
-  className,
-  strokeWidth,
-  ...rest
-}: IconProps) {
+export function NavigationIcon({ size, color, className }: IconProps) {
   return (
     <>
-      <Menu
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      ></Menu>
+      <LuMenu size={size} color={color} className={className}></LuMenu>
     </>
   );
 }

--- a/src/components/icon/ProfileIcon.tsx
+++ b/src/components/icon/ProfileIcon.tsx
@@ -1,17 +1,6 @@
-import { CircleUserRound } from 'lucide-react';
-import type { IconProps } from '@/components/types/type';
+import { LuCircleUserRound } from 'react-icons/lu';
+import type { IconProps } from '@/components/types';
 
-export function ProfileIcon({ width, height, color, className, strokeWidth, ...rest }: IconProps) {
-  return (
-    <>
-      <CircleUserRound
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      ></CircleUserRound>
-    </>
-  );
+export function ProfileIcon({ size, color, className }: IconProps) {
+  return <LuCircleUserRound size={size} color={color} className={className}></LuCircleUserRound>;
 }

--- a/src/components/icon/SearchIcon.tsx
+++ b/src/components/icon/SearchIcon.tsx
@@ -1,17 +1,10 @@
-import { Search } from 'lucide-react';
-import type { IconProps } from '@/components/types/type';
+import { LuSearch } from 'react-icons/lu';
+import type { IconProps } from '@/components/types';
 
-export function SearchIcon({ width, height, color, className, strokeWidth, ...rest }: IconProps) {
+export function SearchIcon({ size, color, className }: IconProps) {
   return (
     <>
-      <Search
-        width={width}
-        height={height}
-        color={color}
-        strokeWidth={strokeWidth}
-        className={className}
-        {...rest}
-      />
+      <LuSearch size={size} color={color} className={className} />
     </>
   );
 }

--- a/src/components/icon/SocialLinksIcon.tsx
+++ b/src/components/icon/SocialLinksIcon.tsx
@@ -1,2 +1,48 @@
-// import { SocialIcon } from 'react-social-icons';
-// import type { SocialIconProps } from '@/components/types/type';
+import {
+  RiTiktokFill,
+  RiFacebookFill,
+  RiTwitterFill,
+  RiInstagramLine,
+  RiThreadsLine,
+} from 'react-icons/ri';
+import type { IconProps } from '@/components/types';
+
+export function TiktokIcon({ size, color, className }: IconProps) {
+  return (
+    <>
+      <RiTiktokFill size={size} color={color} className={className} />
+    </>
+  );
+}
+
+export function FacebookIcon({ size, color, className }: IconProps) {
+  return (
+    <>
+      <RiFacebookFill size={size} color={color} className={className} />
+    </>
+  );
+}
+
+export function TwitterIcon({ size, color, className }: IconProps) {
+  return (
+    <>
+      <RiTwitterFill size={size} color={color} className={className} />
+    </>
+  );
+}
+
+export function InstagramIcon({ size, color, className }: IconProps) {
+  return (
+    <>
+      <RiInstagramLine size={size} color={color} className={className} />
+    </>
+  );
+}
+
+export function ThreadsIcon({ size, color, className }: IconProps) {
+  return (
+    <>
+      <RiThreadsLine size={size} color={color} className={className} />
+    </>
+  );
+}

--- a/src/components/types/index.ts
+++ b/src/components/types/index.ts
@@ -1,0 +1,1 @@
+export * from './props';

--- a/src/components/types/props.ts
+++ b/src/components/types/props.ts
@@ -9,13 +9,10 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   py?: number | string; // y축 padding
 }
 
-import type { LucideProps } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 
-export interface IconProps extends LucideProps {
-  width?: number | string;
-  height?: number | string;
-  strokeWidth?: number; // 옵션으로 변경
+export interface IconProps {
+  size: number;
   color?: string;
   className?: string;
 }

--- a/src/components/ui/CheckBox.tsx
+++ b/src/components/ui/CheckBox.tsx
@@ -1,4 +1,4 @@
-import type { CheckboxAloneProps, CheckboxProps } from '@/components/types/type';
+import type { CheckboxAloneProps, CheckboxProps } from '@/components/types';
 
 export function CheckBox({ id, label, checked, onChange, className }: CheckboxProps) {
   return (

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,11 +1,11 @@
-import type { ModalProps } from '../types/type';
+import type { ModalProps } from '@/components/types';
 
 export function Modal({ isOpen, closeModal, children, ...rest }: ModalProps) {
   if (!isOpen) return null;
   return (
     <>
       <div
-        className='tems-center fixed inset-0 z-50 flex justify-center bg-black/40'
+        className='fixed inset-0 z-50 flex items-center justify-center bg-black/40'
         onClick={closeModal}
       >
         <div className='modal relative' onClick={(e) => e.stopPropagation()} {...rest}>

--- a/src/components/ui/Radio.tsx
+++ b/src/components/ui/Radio.tsx
@@ -1,4 +1,4 @@
-import type { RadioProps } from '@/components/types/type';
+import type { RadioProps } from '@/components/types';
 
 export function Radio({ id, value, checked, name, onChange, disabled }: RadioProps) {
   return (

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import type { SelectBoxProps } from '@/components/types/type';
+import type { SelectBoxProps } from '@/components/types';
 
 export function Select({
   id,

--- a/src/components/ui/button/FilledButton.tsx
+++ b/src/components/ui/button/FilledButton.tsx
@@ -1,4 +1,4 @@
-import type { ButtonProps } from '@/components/types/type';
+import type { ButtonProps } from '@/components/types';
 
 export function FilledButton({
   label,

--- a/src/components/ui/button/GnbButton.tsx
+++ b/src/components/ui/button/GnbButton.tsx
@@ -1,4 +1,4 @@
-import type { ButtonProps } from '@/components/types/type';
+import type { ButtonProps } from '@/components/types';
 
 export function GnbButton({ label, fullWidth = false, className = '', ...rest }: ButtonProps) {
   return (

--- a/src/components/ui/button/HollowButton.tsx
+++ b/src/components/ui/button/HollowButton.tsx
@@ -1,4 +1,4 @@
-import type { ButtonProps } from '@/components/types/type';
+import type { ButtonProps } from '@/components/types';
 
 export function HollowButton({ label, fullWidth = false, className = '', ...rest }: ButtonProps) {
   return (

--- a/src/components/ui/input/EmailInput.tsx
+++ b/src/components/ui/input/EmailInput.tsx
@@ -1,4 +1,4 @@
-import type { EmailProps } from '@/components/types/type';
+import type { EmailProps } from '@/components/types/props';
 import { useState } from 'react';
 
 export function EmailInput({ value, id, placeholder, fullWidth, onChange }: EmailProps) {

--- a/src/components/ui/input/PasswordInput.tsx
+++ b/src/components/ui/input/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import type { PasswordProps } from '@/components/types/type';
+import type { PasswordProps } from '@/components/types/props';
 import { useState } from 'react';
 
 export function PasswordInput({ value, id, placeholder, fullWidth, onChange }: PasswordProps) {

--- a/src/components/ui/input/SearchInput.tsx
+++ b/src/components/ui/input/SearchInput.tsx
@@ -1,4 +1,4 @@
-import type { SearchProps } from '@/components/types/type';
+import type { SearchProps } from '@/components/types/props';
 import { useState } from 'react';
 
 export default function SearchInput({ value, id, placeholder, fullWidth, onChange }: SearchProps) {


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
기존 아이콘 라이브러리인 `lucide-react`를 `react-icons` 라이브러리로 대체

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #31 

## 🧩 작업 내용 (주요 변경사항)
- `package.json`에서 `lucide-react` 삭제 후 `react-icons` 설치 
- 기존에 `lucide-react`에서 아이콘 import 해오던 파일들 수정
- `src/components/types/type.ts` 파일명을 `props.ts`로 변경
- `types` 폴더에 배럴파일 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
