### PR TITLE
refactor: 기존 버튼들(Filled, Hollow, Gnb)을 공통 컴포넌트로 교체 (#135)

### DIFF
--- a/src/components/ui/button/FilledButton.tsx
+++ b/src/components/ui/button/FilledButton.tsx
@@ -1,5 +1,0 @@
-import type { ButtonProps } from '@/components/types';
-import { ButtonBase } from '@/components/ui/button/ButtonBase';
-export const FilledButton = (props: Omit<ButtonProps, 'variant'>) => (
-  <ButtonBase {...props} variant='filled' />
-);

--- a/src/components/ui/button/GnbButton.tsx
+++ b/src/components/ui/button/GnbButton.tsx
@@ -1,5 +1,0 @@
-import type { ButtonProps } from '@/components/types';
-import { ButtonBase } from '@/components/ui/button/ButtonBase';
-export const GnbButton = (props: Omit<ButtonProps, 'variant'>) => (
-  <ButtonBase {...props} variant='gnb' />
-);

--- a/src/components/ui/button/HollowButton.tsx
+++ b/src/components/ui/button/HollowButton.tsx
@@ -1,5 +1,0 @@
-import type { ButtonProps } from '@/components/types';
-import { ButtonBase } from '@/components/ui/button/ButtonBase';
-export const HollowButton = (props: Omit<ButtonProps, 'variant'>) => (
-  <ButtonBase {...props} variant='hollow' />
-);

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -1,4 +1,1 @@
 export * from './ButtonBase';
-export * from './FilledButton';
-export * from './GnbButton';
-export * from './HollowButton';

--- a/src/features/auth/components/AuthButton.tsx
+++ b/src/features/auth/components/AuthButton.tsx
@@ -1,4 +1,4 @@
-import { GnbButton } from '@/components/ui';
+import { ButtonBase } from '@/components/ui/button/ButtonBase';
 import { useAuthStore } from '@/features/auth';
 
 export function AuthButton() {
@@ -7,8 +7,8 @@ export function AuthButton() {
   if (accessToken) return null;
 
   return (
-    <GnbButton onClick={() => openAuthModal('login')} className='mobile-hidden'>
+    <ButtonBase onClick={() => openAuthModal('login')} className='hidden lg:flex' variant='gnb'>
       로그인/회원가입
-    </GnbButton>
+    </ButtonBase>
   );
 }

--- a/src/features/auth/components/LoginModal.tsx
+++ b/src/features/auth/components/LoginModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAuthStore } from '@/features/auth';
-import { AuthModal, FilledButton, HollowButton } from '@/components/ui';
+import { AuthModal, ButtonBase } from '@/components/ui';
 import naverIcon from '@/assets/naver-icon.svg';
 import { HeaderLogoImgIcon } from '@/components/icon';
 
@@ -59,11 +59,16 @@ export function LoginModal() {
         </div>
         {error && <p className='text-secondary-300 text-sm'>{error}</p>}
         <div className='flex w-full flex-col gap-6'>
-          <FilledButton className='auth-button'>로그인</FilledButton>
-          <HollowButton className='auth-button flex items-center justify-center gap-2'>
+          <ButtonBase className='auth-button' variant='filled'>
+            로그인
+          </ButtonBase>
+          <ButtonBase
+            className='auth-button flex items-center justify-center gap-2'
+            variant='hollow'
+          >
             <img src={naverIcon} alt='Naver' className='h-10 w-10' />
             네이버 간편 로그인
-          </HollowButton>
+          </ButtonBase>
         </div>
       </form>
       <div className='sub-text flex justify-center gap-2'>

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { useAuthStore } from '@/features/auth';
-import { AuthModal, FilledButton } from '@/components/ui';
+import { AuthModal, ButtonBase } from '@/components/ui';
 import { HeaderLogoImgIcon } from '@/components/icon';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -67,9 +67,9 @@ export function SignupForm() {
                 required
                 className='input auth-input'
               />
-              <FilledButton type='button' className='grow'>
+              <ButtonBase type='button' className='grow' variant='filled'>
                 중복확인
-              </FilledButton>
+              </ButtonBase>
             </div>
             {errors.email && <p className='text-secondary-300 text-sm'>{errors.email.message}</p>}
           </div>
@@ -104,9 +104,9 @@ export function SignupForm() {
                 required
                 className='input auth-input'
               />
-              <FilledButton type='button' className='grow'>
+              <ButtonBase type='button' className='grow' variant='filled'>
                 중복확인
-              </FilledButton>
+              </ButtonBase>
             </div>
             {errors.nickname && (
               <p className='text-secondary-300 text-sm'>{errors.nickname.message}</p>
@@ -163,9 +163,14 @@ export function SignupForm() {
           </div>
         </div>
         <div className='flex w-full flex-col gap-6'>
-          <FilledButton type='submit' className='auth-button' disabled={isSubmitting}>
+          <ButtonBase
+            type='submit'
+            className='auth-button'
+            disabled={isSubmitting}
+            variant='filled'
+          >
             {isSubmitting ? '회원가입 중...' : '회원가입'}
-          </FilledButton>
+          </ButtonBase>
         </div>
       </form>
       <div className='sub-text flex justify-center gap-2'>

--- a/src/features/cart/CartList.tsx
+++ b/src/features/cart/CartList.tsx
@@ -1,6 +1,6 @@
 import { useCartQuery } from '@/features/cart/api/useCartQuery';
 import type { CartItem } from '@/types/order';
-import { CheckBox, FilledButton, GnbButton } from '@/components/ui';
+import { CheckBox, ButtonBase } from '@/components/ui';
 import { useNavigate } from 'react-router-dom';
 import { usdToKrw } from '@/features/cart/api/currency';
 import { CartCard } from '@/features/cart/CartCard';
@@ -93,7 +93,9 @@ export default function CartList() {
             onChange={(e) => handleSelectAll(e.target.checked)}
             className='pdr-3 text-base'
           />
-          <GnbButton onClick={removeCheckedItems}>선택 삭제</GnbButton>
+          <ButtonBase onClick={removeCheckedItems} variant='gnb'>
+            선택 삭제
+          </ButtonBase>
         </div>
 
         {storeItems.map((product) => (
@@ -151,9 +153,9 @@ export default function CartList() {
               </span>
             </li>
           </ul>
-          <FilledButton className='mt-7' variant='filled' fullWidth onClick={handlePurchase}>
+          <ButtonBase className='mt-7' variant='filled' fullWidth onClick={handlePurchase}>
             {`${totalPayment.toLocaleString()}원 구매하기 (${totalQuantity}개)`}
-          </FilledButton>
+          </ButtonBase>
         </div>
       </div>
     </div>

--- a/src/features/order/OrderList.tsx
+++ b/src/features/order/OrderList.tsx
@@ -3,7 +3,7 @@
 import { useCartQuery } from '@/features/cart/api/useCartQuery';
 import { useOrderStore } from './store/useOrderStore';
 // import type { CartItem } from '@/types/order';
-import { FilledButton, GnbButton } from '@/components/ui';
+import { ButtonBase } from '@/components/ui';
 import { CartCardNone } from '../cart';
 import { OrderCheckoutPage } from './OrderCheckoutPage';
 import { useRewardStore } from '@/features/reward/store/useRewardStore';
@@ -57,9 +57,13 @@ export default function OrderList() {
     <div className='sub-info-half-content-with-wrap m-auto flex w-full'>
       <div className='sub-info-half-content w-[600px] bg-white px-7.5 py-5'>
         <div className='relative px-2.5'>
-          <GnbButton className='absolute top-0 right-0' onClick={handleClickEditAddress}>
+          <ButtonBase
+            className='absolute top-0 right-0'
+            onClick={handleClickEditAddress}
+            variant='gnb'
+          >
             배송지 변경
-          </GnbButton>
+          </ButtonBase>
           <div className='flex h-full items-center justify-start py-2'>
             <span className='text-primary-500-90 mr-2.5 flex text-lg font-bold'>
               {customer?.customerName ?? '주문자'}
@@ -214,9 +218,9 @@ export default function OrderList() {
               </span>
             </li>
           </ul>
-          <FilledButton className='mt-7 text-lg font-bold' variant='filled' fullWidth>
+          <ButtonBase className='mt-7 text-lg font-bold' variant='filled' fullWidth>
             결제하기
-          </FilledButton>
+          </ButtonBase>
         </div>
       </div>
     </div>

--- a/src/pages/mypage/MyPageAddressInfo.tsx
+++ b/src/pages/mypage/MyPageAddressInfo.tsx
@@ -2,7 +2,7 @@ import { MypageNav } from '@/features/mypage/components/MypageNav';
 import MypageOutside from '@/features/mypage/components/MypageOutside';
 import { MypageContentsWrap } from '@/features/mypage/components/MypageContentsWrap';
 import { MyPageProfile } from '../../features/mypage/components';
-import { FilledButton } from '@/components/ui/button';
+import { ButtonBase } from '@/components/ui';
 import { useAddressQuery } from '@/features/mypage/api/useAddressQuery';
 // import { useAddressMutation, useAddressQuery } from '@/features/mypage/api/useAddressQuery';
 
@@ -17,7 +17,7 @@ export function MyPageAddressInfo() {
         <div className='mt-10 pb-5'>
           <p className='flex border-b border-black pb-3 text-lg font-bold'>배송지 정보 조회/수정</p>
           <div className='mt-6 flex justify-end'>
-            <FilledButton>배송지 추가하기</FilledButton>
+            <ButtonBase variant='filled'>배송지 추가하기</ButtonBase>
           </div>
           {addresses.map((addrinfo) => (
             <div

--- a/src/pages/mypage/MyPageInfo.tsx
+++ b/src/pages/mypage/MyPageInfo.tsx
@@ -2,7 +2,7 @@ import { useCustomerQuery } from '@/features/order/api/useCustomerQuery';
 import { MyPageInfoRow } from '@/features/mypage/components/MyPageInfoRow';
 import { MypageNav } from '@/features/mypage/components/MypageNav';
 import { MyPageProfile } from '@/features/mypage/components/MyPageProfile';
-import { FilledButton, HollowButton } from '@/components/ui';
+import { ButtonBase } from '@/components/ui';
 import MypageOutside from '../../features/mypage/components/MypageOutside';
 import { MypageContentsWrap } from '../../features/mypage/components/MypageContentsWrap';
 
@@ -31,15 +31,17 @@ export function MyPageInfo() {
             <MyPageInfoRow rowTitle={`닉네임`} rowContent={`${customer?.customerNickrname}`} />
             <MyPageInfoRow
               rowTitle={`비밀번호`}
-              rowContent={<HollowButton>비밀번호 변경</HollowButton>}
+              rowContent={<ButtonBase variant='hollow'>비밀번호 변경</ButtonBase>}
             />
             <MyPageInfoRow rowTitle={`연락처`} rowContent={`${customer?.customerMobilePhone}`} />
           </ul>
           <div className='flex flex-row justify-center pt-15 pb-10'>
-            <HollowButton onClick={handleClickWithdraw}>회원 탈퇴</HollowButton>
-            <FilledButton className='ml-5' onClick={handleClickEditInfoConfirm}>
+            <ButtonBase onClick={handleClickWithdraw} variant='hollow'>
+              회원 탈퇴
+            </ButtonBase>
+            <ButtonBase className='ml-5' onClick={handleClickEditInfoConfirm} variant='filled'>
               회원 정보 수정
-            </FilledButton>
+            </ButtonBase>
           </div>
         </div>
       </MypageContentsWrap>


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
기존에 쓰던 버튼 컴포넌트들 교체

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #135 
References #120 

## 🧩 작업 내용 (주요 변경사항)
- 기존에 쓰던 버튼 컴포넌트들(`FilledButton`, `HollowButton`, `GnbButton`)을 `ButtonBase` 컴포넌트로 교체
- 배럴 파일 수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
다들 pull 받아주시기~

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
