### PR TITLE
feat: 헤더에 모바일용 메뉴 추가 (#154)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tosspayments/tosspayments-sdk": "^2.4.1",
         "axios": "^1.12.2",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.24",
         "husky": "^9.1.7",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
@@ -4502,6 +4503,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6208,6 +6236,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -7797,7 +7840,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tosspayments/tosspayments-sdk": "^2.4.1",
     "axios": "^1.12.2",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.24",
     "husky": "^9.1.7",
     "postcss": "^8.5.6",
     "react": "^19.1.1",

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,14 +1,19 @@
 import { HeaderLogoIcon, MenuIcon } from '@/components/icon';
-import { HeaderIcons, HeaderNav } from '@/components/layout';
+import { HeaderIcons, HeaderMobileNav, HeaderNav } from '@/components/layout';
 import { AuthButton } from '@/features/auth';
 import { SearchModal } from '@/features/search';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useToggleMenuStore } from '@/store';
 
 export function Header() {
+  const { isOpen, toggleMenu } = useToggleMenuStore();
   return (
     <header className='fixed top-0 z-100 flex w-full justify-center bg-white'>
       <div className='bg-primary-100 container-1200 flex h-16 grow items-center justify-between px-8'>
         <div className='flex gap-8'>
-          <MenuIcon className='md:hidden' />
+          <button className='md:hidden' onClick={toggleMenu} aria-label='메뉴 열기'>
+            {isOpen ? <div className='pt-0.5 text-xl font-black'>✕</div> : <MenuIcon />}
+          </button>
           <HeaderLogoIcon width={48} />
           <HeaderNav />
         </div>
@@ -18,6 +23,20 @@ export function Header() {
           <AuthButton />
         </div>
       </div>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.nav
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className='bg-primary-100 absolute top-16 left-0 w-full pb-8 md:hidden'
+          >
+            <div>
+              <HeaderMobileNav />
+            </div>
+          </motion.nav>
+        )}
+      </AnimatePresence>
     </header>
   );
 }

--- a/src/components/layout/header/HeaderMobileNav.tsx
+++ b/src/components/layout/header/HeaderMobileNav.tsx
@@ -1,0 +1,24 @@
+import { HEADER_ICONS_LINKS, HEADER_NAV_LINKS, type HeaderIconLinkType } from '@/constants';
+import { useToggleMenuStore } from '@/store';
+import { Link } from 'react-router-dom';
+
+export function HeaderMobileNav() {
+  const closeMenu = useToggleMenuStore((state) => state.closeMenu);
+  return (
+    <div className='flex flex-col items-center gap-8 text-lg font-black md:hidden'>
+      {HEADER_NAV_LINKS.map(({ label, href }) => (
+        <Link key={label} to={href} onClick={closeMenu}>
+          {label}
+        </Link>
+      ))}
+      {HEADER_ICONS_LINKS.filter(
+        (link): link is Extract<HeaderIconLinkType, { type: 'link' }> =>
+          link.type === 'link' && link.responsiveClass === 'mobile-hidden'
+      ).map((link) => (
+        <Link key={link.label} to={link.href} onClick={closeMenu}>
+          {link.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/header/index.ts
+++ b/src/components/layout/header/index.ts
@@ -1,3 +1,4 @@
 export * from './Header';
+export * from './HeaderMobileNav';
 export * from './HeaderNav';
 export * from './HeaderIcons';

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -10,7 +10,7 @@ export const HEADER_NAV_LINKS = [
   { href: '/about', label: 'ABOUT' },
 ];
 
-type HeaderIconLink =
+export type HeaderIconLinkType =
   | {
       type: 'action';
       action: string;
@@ -26,32 +26,32 @@ type HeaderIconLink =
       responsiveClass?: string;
     };
 
-export const HEADER_ICONS_LINKS: HeaderIconLink[] = [
+export const HEADER_ICONS_LINKS: HeaderIconLinkType[] = [
   {
     type: 'action',
     action: 'openSearchModal',
-    label: 'search',
+    label: 'SEARCH',
     Icon: SearchToggleButton,
     responsiveClass: 'mobile-visible',
   },
   {
     type: 'link',
     href: '/users',
-    label: 'My Page',
+    label: 'MYPAGE',
     Icon: ProfileIcon,
     responsiveClass: 'mobile-visible',
   },
   {
     type: 'link',
     href: '/users/favorites',
-    label: 'Favorites',
+    label: 'FAVORITES',
     Icon: EmptyHeartIcon,
     responsiveClass: 'mobile-hidden',
   },
   {
     type: 'link',
     href: '/users/cart',
-    label: 'Cart',
+    label: 'CART',
     Icon: CartIcon,
     responsiveClass: 'mobile-hidden',
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,2 @@
+export * from './useAddressModalStore';
+export * from './useToggleMenuStore';

--- a/src/store/useToggleMenuStore.ts
+++ b/src/store/useToggleMenuStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+type ToggleMenuState = {
+  isOpen: boolean;
+  openMenu: () => void;
+  closeMenu: () => void;
+  toggleMenu: () => void;
+};
+
+export const useToggleMenuStore = create<ToggleMenuState>((set) => ({
+  isOpen: false,
+  openMenu: () => set({ isOpen: true }),
+  closeMenu: () => set({ isOpen: false }),
+  toggleMenu: () => set((state) => ({ isOpen: !state.isOpen })),
+}));


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
모바일 화면용 메뉴 헤더에 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #154 

## 🧩 작업 내용 (주요 변경사항)
- `framer-motion` 라이브러리 설치 (메뉴에 사용)
- `HeaderMobileNav` 컴포넌트 추가
- `HeaderMobileNav`에 맞게 `navigation.ts`의 상수 수정
- 메뉴 토글용 스토어 생성

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
오타나 오류 있는지 한번씩 봐주세요! 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
