### PR TITLE
feat: 네이버 로그인 로직 구현 (#164)

### DIFF
--- a/src/features/auth/api/authAPI.ts
+++ b/src/features/auth/api/authAPI.ts
@@ -1,4 +1,4 @@
-import { API_ENDPOINTS, backendAPI } from '@/features/auth/api';
+import { API_ENDPOINTS, backendAPI } from '@/features/auth';
 
 export const authLogin = (data: { email: string; password: string }) =>
   backendAPI.post(API_ENDPOINTS.LOGIN, data);

--- a/src/features/auth/components/LoginModal.tsx
+++ b/src/features/auth/components/LoginModal.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import { useAuthStore } from '@/features/auth';
+import { NaverLoginButton, useAuthStore } from '@/features/auth';
 import { AuthModal, ButtonBase } from '@/components/ui';
-import naverIcon from '@/assets/naver-icon.svg';
 import { HeaderLogoImgIcon } from '@/components/icon';
 
 export function LoginModal() {
@@ -59,16 +58,10 @@ export function LoginModal() {
         </div>
         {error && <p className='text-secondary-300 text-sm'>{error}</p>}
         <div className='flex w-full flex-col gap-6'>
-          <ButtonBase className='auth-button' variant='filled'>
+          <ButtonBase className='auth-button' variant='filled' type='submit'>
             로그인
           </ButtonBase>
-          <ButtonBase
-            className='auth-button flex items-center justify-center gap-2'
-            variant='hollow'
-          >
-            <img src={naverIcon} alt='Naver' className='h-10 w-10' />
-            네이버 간편 로그인
-          </ButtonBase>
+          <NaverLoginButton />
         </div>
       </form>
       <div className='sub-text flex justify-center gap-2'>

--- a/src/features/auth/components/NaverLoginButton.tsx
+++ b/src/features/auth/components/NaverLoginButton.tsx
@@ -1,0 +1,25 @@
+import { ButtonBase } from '@/components/ui';
+import naverIcon from '@/assets/naver-icon.svg';
+
+export function NaverLoginButton() {
+  const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
+  const REDIRECT_URI = `${import.meta.env.VITE_FRONT_URL}/auth/naver/callback`;
+  const STATE = crypto.randomUUID();
+
+  const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${STATE}`;
+
+  const handleLogin = () => {
+    window.location.href = NAVER_AUTH_URL;
+  };
+
+  return (
+    <ButtonBase
+      onClick={handleLogin}
+      className='auth-button flex items-center justify-center gap-2'
+      variant='hollow'
+    >
+      <img src={naverIcon} alt='Naver' className='h-10 w-10' />
+      네이버 간편 로그인
+    </ButtonBase>
+  );
+}

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -40,6 +40,7 @@ export function SignupForm() {
   const onSubmit = async (data: SignupFormData) => {
     try {
       await signup(data.email, data.password);
+      alert('회원가입 완료! 이메일 인증을 위해 메일함을 확인해주세요.');
       closeAuthModal();
     } catch (err: any) {
       console.error('회원가입 실패:', err);

--- a/src/features/auth/components/index.ts
+++ b/src/features/auth/components/index.ts
@@ -1,3 +1,4 @@
 export * from './AuthButton';
 export * from './LoginModal';
+export * from './NaverLoginButton';
 export * from './SignupForm';

--- a/src/pages/CallbackPage.tsx
+++ b/src/pages/CallbackPage.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { backendAPI } from '@/features/auth';
+import { useAuthStore } from '@/features/auth';
+
+export function CallbackPage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+
+      if (!code || !state) {
+        alert('로그인 실패');
+        return navigate('/');
+      }
+
+      try {
+        const res = await backendAPI.post('/auth/naver/callback', { code, state });
+        const { accessToken } = res.data;
+
+        useAuthStore.getState().setToken(accessToken);
+        navigate('/');
+      } catch (err) {
+        console.error('네이버 로그인 실패:', err);
+        alert('네이버 로그인 실패');
+        navigate('/');
+      }
+    };
+
+    handleCallback();
+  }, [navigate]);
+
+  return <p>네이버 로그인 처리 중...</p>;
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,5 @@
 export * from './AboutPage';
+export * from './CallbackPage';
 export * from './CartPage';
 export * from './FavoritesPage';
 export * from './MainPage';


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
빈 UI에 네이버 로그인 로직 구현

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

## 🧩 작업 내용 (주요 변경사항)
- 로그인 모달에 있던 네이버 로그인 버튼을 새로 생성한 `NaverLoginButton` 컴포넌트로 대체 
- 콜백시 띄울 `CallbackPage` 생성
- `authAPI` import 경로 정리
- 회원가입시 이메일 인증 메세지 뜨게 수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
