### PR TITLE
feat: ProductsPage와 FavoritePage의 더미 API를 백엔드 API로 교체 (#195)

### DIFF
--- a/src/features/favorite/FavoriteIcon.tsx
+++ b/src/features/favorite/FavoriteIcon.tsx
@@ -1,9 +1,9 @@
-import type { DummyType } from '@/types';
+import type { ProductCardType } from '@/types';
 import { useFavoriteStore } from './store';
 import { EmptyHeartIcon, FilledHeartIcon } from '@/components/icon';
 
 interface FavoriteIconProps {
-  product: DummyType; //나중에 ProductCardType으로 변경
+  product: ProductCardType;
   className?: string;
 }
 

--- a/src/features/favorite/store/favoritestore.ts
+++ b/src/features/favorite/store/favoritestore.ts
@@ -1,11 +1,10 @@
-import type { DummyType } from '@/types';
+import type { ProductCardType } from '@/types';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type FavoriteState = {
-  favoriteProducts: DummyType[];
-  toggleFavorite: (product: DummyType) => void;
-  //나중에 ProductCardType으로 변경
+  favoriteProducts: ProductCardType[];
+  toggleFavorite: (product: ProductCardType) => void;
 };
 
 export const useFavoriteStore = create<FavoriteState>()(

--- a/src/features/product/ProductCard.tsx
+++ b/src/features/product/ProductCard.tsx
@@ -1,10 +1,10 @@
 import { Link } from 'react-router-dom';
 import { ReviewRating } from '@/components/ui';
-import type { DummyType } from '@/types';
+import type { ProductCardType } from '@/types';
 import { FavoriteIcon } from '@/features/favorite';
 
 interface ProductCardProps {
-  product: DummyType; //나중에 ProductCardType으로 변경
+  product: ProductCardType;
 }
 
 export function ProductCard({ product }: ProductCardProps) {
@@ -13,8 +13,8 @@ export function ProductCard({ product }: ProductCardProps) {
       <div className='flex max-h-[600px] min-h-96 min-w-60 flex-col items-center justify-center gap-4 text-center'>
         <div className='relative flex h-full w-full flex-col'>
           <img
-            src={product.images[0]} //product.product_image.product_card_image
-            alt={product.title} //product.product_name
+            src={product.product_image.product_card_image}
+            alt={product.product_name}
             className='h-auto w-full min-w-32 object-cover object-top'
             width={300}
             height={400}
@@ -23,11 +23,11 @@ export function ProductCard({ product }: ProductCardProps) {
         </div>
 
         <div className='flex h-20 w-full grow flex-col justify-evenly gap-2 text-left text-xs'>
-          <h2>{product.brand}</h2>
-          <h3 className='font-bold'>{product.title}</h3>
-          <div className='flex items-center justify-between gap-2'>
-            <p className='font-bold'>₩{Number(product.price).toLocaleString('ko-KR')}</p>{' '}
-            <ReviewRating initialValue={Number(product.rating)} readOnly size={16} />
+          <h2>{product.brand_name}</h2>
+          <h3 className='font-bold'>{product.product_name}</h3>
+          <div className='flex items-center justify-between pr-0.5'>
+            <p className='font-bold'>₩{Number(product.product_value).toLocaleString('ko-KR')}</p>
+            <ReviewRating initialValue={Number(product.product_rating)} readOnly size={16} />
           </div>
         </div>
       </div>

--- a/src/features/product/ProductGrid.tsx
+++ b/src/features/product/ProductGrid.tsx
@@ -1,8 +1,8 @@
-import type { DummyType } from '@/types';
+import type { ProductCardType } from '@/types';
 import { ProductCard } from '@/features/product';
 
 interface ProductGridProps {
-  products: DummyType[]; //나중에 ProductCardType으로 변경
+  products: ProductCardType[];
 }
 
 export function ProductGrid({ products }: ProductGridProps) {

--- a/src/features/product/hooks/useProductsQuery.ts
+++ b/src/features/product/hooks/useProductsQuery.ts
@@ -5,12 +5,12 @@ export function useProductsQuery(sortOption: string = '') {
   return useQuery({
     queryKey: ['products', sortOption],
     queryFn: async () => {
-      const res = await axios.get('https://dummyjson.com/products', {
+      const res = await axios.get(`${import.meta.env.VITE_API_URL}/products`, {
         params: {
           ordering: sortOption,
         },
       });
-      return res.data.products;
+      return res.data ?? [];
     },
   });
 }

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -1,7 +1,7 @@
 import { ProductGrid, ProductSort, useProductsQuery } from '@/features/product';
 import { ErrorMessage, Spinner } from '@/components/ui';
 import { useSearchStore } from '@/features/search';
-import type { DummyType } from '@/types';
+import type { ProductCardType } from '@/types';
 import { useMemo, useState } from 'react';
 
 export function ProductsPage() {
@@ -11,8 +11,8 @@ export function ProductsPage() {
 
   const filteredProducts = useMemo(() => {
     if (!products) return [];
-    return products.filter((p: DummyType) =>
-      p.title.toLowerCase().includes(searchTerm.toLowerCase())
+    return products.filter((p: ProductCardType) =>
+      p.product_name.toLowerCase().includes(searchTerm.toLowerCase())
     );
   }, [products, searchTerm]);
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
ProductsPage와 FavoritePage의 더미 API를 백엔드 API로 교체

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #195

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
오타나 이상한 점 없는지 봐주세요

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
나머지 파일들은 애매할 것 같아서 안 바꿔놨습니다 (`ProductSection` 제외)

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
