### PR TITLE
refactor: 네이버 로그인 로직 백엔드 직통 방식으로 변경 및 불필요 env 제거 (#222)

### DIFF
--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -1,3 +1,2 @@
 export * from './authAPI';
 export * from './endpoints';
-export * from './socialAPI';

--- a/src/features/auth/api/socialAPI.ts
+++ b/src/features/auth/api/socialAPI.ts
@@ -1,5 +1,0 @@
-import { backendAPI } from '@/api';
-import { API_ENDPOINTS } from '@/features/auth';
-
-export const socialNaverLogin = (data: { code: string; state: string | null }) =>
-  backendAPI.post(API_ENDPOINTS.NAVER_LOGIN, data);

--- a/src/features/auth/components/NaverLoginButton.tsx
+++ b/src/features/auth/components/NaverLoginButton.tsx
@@ -1,15 +1,12 @@
 import { ButtonBase } from '@/components/ui';
 import { naverIcon } from '@/assets';
+import { API_ENDPOINTS } from '../api';
 
 export function NaverLoginButton() {
-  const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
-  const REDIRECT_URI = `${import.meta.env.VITE_API_URL}/auth/naver/callback`;
-  const STATE = crypto.randomUUID();
-
-  const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${STATE}`;
+  const NAVER_LOGIN_URL = `${import.meta.env.VITE_API_URL}${API_ENDPOINTS.NAVER_LOGIN}`;
 
   const handleLogin = () => {
-    window.location.href = NAVER_AUTH_URL;
+    window.location.href = NAVER_LOGIN_URL;
   };
 
   return (

--- a/src/features/auth/store/authstore.ts
+++ b/src/features/auth/store/authstore.ts
@@ -10,6 +10,7 @@ interface AuthState {
   user: any | null;
   authModalType: AuthModalType;
   setToken: (accessToken: string) => void;
+  setUser: (user: any) => void;
   openAuthModal: (type: AuthModalType) => void;
   closeAuthModal: () => void;
   signup: (email: string, password: string) => Promise<void>;
@@ -26,6 +27,7 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       authModalType: null,
       setToken: (accessToken) => set({ accessToken }),
+      setUser: (user) => set({ user }),
       openAuthModal: (type) => set({ authModalType: type }),
       closeAuthModal: () => set({ authModalType: null }),
       signup: async (email, password) => {

--- a/src/pages/CallbackPage.tsx
+++ b/src/pages/CallbackPage.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { socialNaverLogin } from '@/features/auth';
+import { useAuthStore } from '@/features/auth';
+import axios from 'axios';
 
 export function CallbackPage() {
   const navigate = useNavigate();
+  const setToken = useAuthStore((state) => state.setToken);
+  const setUser = useAuthStore((state) => state.setUser);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -12,16 +15,22 @@ export function CallbackPage() {
 
     if (!code || !state) {
       alert('로그인 실패');
-      navigate('/');
+      navigate('/auth/login');
       return;
     }
 
-    socialNaverLogin({ code, state })
-      .then(() => {
+    axios
+      .get(`${import.meta.env.VITE_API_URL}/auth/naver/callback`, {
+        params: { code, state },
+        withCredentials: true,
+      })
+      .then((res) => {
+        const { accessToken, user } = res.data;
+        setToken(accessToken);
+        setUser(user);
         navigate('/');
       })
       .catch(() => {
-        alert('네이버 로그인 실패');
         navigate('/login');
       });
   }, []);


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
네이버 로그인 로직 백엔드 직통 방식으로 변경 및 불필요한 `env` 코드 제거

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #222 

## 🧩 작업 내용 (주요 변경사항)
- `NaverLoginButton` url 변경
- `CallbackPage` 로직 변경
- 사용되지 않는 `socialAPI` 파일 삭제

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
