### PR TITLE
fix: ProductSection 타입 에러 해결 (#245)

### DIFF
--- a/src/features/product/hooks/useProductsQuery.ts
+++ b/src/features/product/hooks/useProductsQuery.ts
@@ -1,3 +1,4 @@
+import type { ProductType } from '@/types';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -14,7 +15,7 @@ export function useProductsQuery({
   hasDiscount,
   sortOption,
 }: UseProductsParams = {}) {
-  return useQuery({
+  return useQuery<ProductType[]>({
     queryKey: ['products', category ?? 'all', hasReview, hasDiscount, sortOption],
     queryFn: async () => {
       const params: Record<string, any> = {};

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -14,48 +14,48 @@ export interface ProductType {
   brand_name: string;
   product_image: [{ product_card_image: string; product_explain_image: string }];
   brand_image: [{ brand_image: string }];
+  favorite_count?: number;
 }
 
-export interface ProductCardType {
-  id: number;
-  product_name: string;
-  brand_name: string;
-  product_value: string;
-  dc_value: number;
-  product_rating: string;
-  product_image: [
-    {
-      product_card_image: string;
-    },
-  ];
+export interface ProductCardType
+  extends Pick<
+    ProductType,
+    'id' | 'product_name' | 'brand_name' | 'product_value' | 'dc_value' | 'product_rating'
+  > {
+  product_image: { product_card_image: string }[];
 }
 
-export interface ProductDetailType {
-  id: number;
-  product_name: string;
-  product_value: number;
-  product_stock: number;
-  discount_rate: number;
-  product_rating: number;
-  dc_value: number;
-  category_name: string;
-  brand_name: string;
-  product_image: [{ product_card_image: string; product_explain_image: string }];
-  brand_image: [{ brand_image: string }];
-}
+export interface ProductDetailType
+  extends Pick<
+    ProductType,
+    | 'id'
+    | 'product_name'
+    | 'product_value'
+    | 'product_stock'
+    | 'discount_rate'
+    | 'product_rating'
+    | 'dc_value'
+    | 'category_name'
+    | 'brand_name'
+    | 'product_image'
+    | 'brand_image'
+    | 'favorite_count'
+  > {}
 
-export interface ProductCartType {
-  id: number;
-  product_name: string;
-  product_value: number;
-  discount_rate: number;
-  product_rating: number;
-  dc_value: number;
-  category_name: string;
-  brand_name: string;
-  product_image: [{ product_card_image: string; product_explain_image: string }];
-  brand_image: [{ brand_image: string }];
-}
+export interface ProductCartType
+  extends Pick<
+    ProductType,
+    | 'id'
+    | 'product_name'
+    | 'product_value'
+    | 'discount_rate'
+    | 'product_rating'
+    | 'dc_value'
+    | 'category_name'
+    | 'brand_name'
+    | 'product_image'
+    | 'brand_image'
+  > {}
 
 export interface ProductReviewType {
   id: number;
@@ -77,24 +77,4 @@ export interface ProductReviewType {
   rating: number;
   created_at: string;
   updated_at: string;
-}
-
-export interface ProductDetailType {
-  id: number;
-  product_name: string;
-  product_value: number;
-  product_stock: number;
-  discount_rate: number;
-  product_rating: number;
-  dc_value: number;
-  category_name: string;
-  brand_name: string;
-  product_image: [
-    { product_card_image: string;
-      product_explain_image: string },
-    ];
-  brand_image: [
-    { brand_image: string },
-  ];
-  favorite_count?: number;
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
타입 지정으로 `ProductSection` 타입 에러 해결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #245 

## 🧩 작업 내용 (주요 변경사항)
- `useProductsQuery`에 제네릭으로 `ProductType[]` 명시
- 기존에 별도 정의한 `ProductCardType`, `ProductDetailType`, `ProductCartType`에서 타입 충돌 발생
- `ProductType`을 기준으로 하위 타입을 `extends Pick<>` 방식으로 정의

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
이래도 안 되면 조금 슬플 것 같긴 하네요...

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
