### PR TITLE
fix: 회원가입 요청 데이터 백엔드 스펙에 맞게 수정 (#251)

### DIFF
--- a/src/features/auth/api/authAPI.ts
+++ b/src/features/auth/api/authAPI.ts
@@ -4,8 +4,13 @@ import { API_ENDPOINTS } from '@/features/auth';
 export const authLogin = (data: { email: string; password: string }) =>
   backendAPI.post(API_ENDPOINTS.LOGIN, data);
 
-export const authSignup = (data: { email: string; password: string }) =>
-  backendAPI.post(API_ENDPOINTS.SIGNUP, data);
+export const authSignup = (data: {
+  email: string;
+  password: string;
+  username: string;
+  nickname: string;
+  phone_number: string;
+}) => backendAPI.post(API_ENDPOINTS.SIGNUP, data);
 
 export const authLogout = () => backendAPI.post(API_ENDPOINTS.LOGOUT);
 

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -25,7 +25,7 @@ const signupSchema = z
     path: ['confirmPassword'],
   });
 
-type SignupFormData = z.infer<typeof signupSchema>;
+export type SignupFormData = z.infer<typeof signupSchema>;
 
 export function SignupForm() {
   const { signup, openAuthModal, closeAuthModal, authModalType } = useAuthStore();
@@ -39,7 +39,7 @@ export function SignupForm() {
 
   const onSubmit = async (data: SignupFormData) => {
     try {
-      await signup(data.email, data.password);
+      await signup(data);
       alert('회원가입 완료! 이메일 인증을 위해 메일함을 확인해주세요.');
       closeAuthModal();
     } catch (err: any) {

--- a/src/features/auth/store/authstore.ts
+++ b/src/features/auth/store/authstore.ts
@@ -1,4 +1,5 @@
 import { authLogin, authSignup, authLogout, authRefreshToken } from '@/features/auth';
+import type { SignupFormData } from '@/features/auth';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
@@ -13,7 +14,7 @@ interface AuthState {
   setUser: (user: any) => void;
   openAuthModal: (type: AuthModalType) => void;
   closeAuthModal: () => void;
-  signup: (email: string, password: string) => Promise<void>;
+  signup: (data: SignupFormData) => Promise<void>;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
   refresh: () => Promise<void>;
@@ -30,9 +31,15 @@ export const useAuthStore = create<AuthState>()(
       setUser: (user) => set({ user }),
       openAuthModal: (type) => set({ authModalType: type }),
       closeAuthModal: () => set({ authModalType: null }),
-      signup: async (email, password) => {
-        await authSignup({ email, password });
-        await get().login(email, password);
+      signup: async (data) => {
+        await authSignup({
+          email: data.email,
+          password: data.password,
+          username: data.username,
+          nickname: data.nickname,
+          phone_number: data.phone,
+        });
+        await get().login(data.email, data.password);
       },
       login: async (email, password) => {
         const res = await authLogin({ email, password });


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
회원가입 요청 데이터(`email`, `password`)를 백엔드 스펙(`email`, `password`, `username`, `nickname`, `phone_number`)에 맞게 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #251 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
