### PR TITLE
feat: 이메일 중복확인 로직 추가 (#253)

### DIFF
--- a/src/features/auth/api/authAPI.ts
+++ b/src/features/auth/api/authAPI.ts
@@ -16,3 +16,10 @@ export const authLogout = () => backendAPI.post(API_ENDPOINTS.LOGOUT);
 
 export const authRefreshToken = (data: { refreshToken: string }) =>
   backendAPI.post(API_ENDPOINTS.REFRESH_TOKEN, data);
+
+export const checkEmail = async (email: string) => {
+  const res = await backendAPI.get(API_ENDPOINTS.EMAIL_CHECK, {
+    params: { email },
+  });
+  return res.data;
+};

--- a/src/features/auth/api/endpoints.ts
+++ b/src/features/auth/api/endpoints.ts
@@ -4,4 +4,5 @@ export const API_ENDPOINTS = {
   LOGOUT: '/auth/logout',
   REFRESH_TOKEN: '/token/refresh',
   NAVER_LOGIN: '/auth/naver/login',
+  EMAIL_CHECK: '/users/email/exist',
 };


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
회원가입 폼에 이메일 중복확인 로직 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #253 

## 🧩 작업 내용 (주요 변경사항)
- `EMAIL_CHECK: '/users/email/exist'` 엔드포인트 추가
- `checkEmail` 함수 구현
- `SignupForm`에서 이메일 중복확인 버튼에 로직 적용

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
