### PR TITLE
fix: 검색 라우팅 경로 수정 및 관련 컴포넌트 업데이트 (#345)

### DIFF
--- a/src/features/search/SearchModal.tsx
+++ b/src/features/search/SearchModal.tsx
@@ -3,8 +3,7 @@ import type { MouseEvent } from 'react';
 import { SearchIcon } from '@/components/icon';
 
 export function SearchModal() {
-  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal, resetSearch } =
-    useSearchStore();
+  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal } = useSearchStore();
   useSearchNavigation();
 
   if (!isOpenSearchModal) return null;
@@ -12,7 +11,6 @@ export function SearchModal() {
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       closeSearchModal();
-      resetSearch();
     }
   };
 
@@ -36,7 +34,6 @@ export function SearchModal() {
           <button
             onClick={() => {
               closeSearchModal();
-              resetSearch();
             }}
             className='text-primary-700 ml-4 text-2xl font-black'
           >

--- a/src/features/search/hooks/useSearchNavigation.ts
+++ b/src/features/search/hooks/useSearchNavigation.ts
@@ -10,7 +10,7 @@ export function useSearchNavigation() {
 
   useEffect(() => {
     if (debouncedSearchTerm && location.search !== `?q=${debouncedSearchTerm}`) {
-      navigate(`products/search?q=${debouncedSearchTerm}`);
+      navigate(`/products?q=${debouncedSearchTerm}`);
     }
   }, [debouncedSearchTerm, navigate, location.search]);
 }

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -1,8 +1,7 @@
 import { ProductGrid, ProductSort, useProductsQuery } from '@/features/product';
 import { ErrorMessage, Spinner } from '@/components/ui';
 import { useSearchStore } from '@/features/search';
-import type { ProductCardType } from '@/types';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export function ProductsPage() {
@@ -10,14 +9,16 @@ export function ProductsPage() {
   const [searchParams] = useSearchParams();
   const category = searchParams.get('category') ?? undefined;
   const [sortOption, setSortOption] = useState('');
-  const { data: products, isLoading, isError } = useProductsQuery({ sortOption, category });
 
-  const filteredProducts = useMemo(() => {
-    if (!products) return [];
-    return products.filter((p: ProductCardType) =>
-      p.product_name.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [products, searchTerm]);
+  const {
+    data: products,
+    isLoading,
+    isError,
+  } = useProductsQuery({
+    sortOption,
+    category,
+    searchTerm,
+  });
 
   if (isLoading) return <Spinner />;
   if (isError) return <ErrorMessage message='상품을 불러오는 중 오류가 발생했습니다.' />;
@@ -28,7 +29,11 @@ export function ProductsPage() {
         <h1 className='text-xl font-bold'>상품 목록</h1>
         <ProductSort selectedOption={sortOption} onChange={setSortOption} />
       </div>
-      <ProductGrid products={filteredProducts} />
+      {products && products.length > 0 ? (
+        <ProductGrid products={products} />
+      ) : (
+        <p>표시할 상품이 없습니다.</p>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
검색 라우팅 경로 수정 및 관련 컴포넌트 업데이트

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #345 

## 🧩 작업 내용 (주요 변경사항)
- `ProductsPage`에서 `searchTerm`을 props로 받아서 검색어 기반 필터링 가능하게 수정
- `useSearchNavigation`에서 잘못된 경로(`products/search`)를 기존 상품 목록 경로로 맞게 수정
- 검색 모달 닫을 때 검색 결과가 즉시 리셋되던 문제를 모달이 닫혀도 검색어/검색 결과 유지되도록 로직 조정해서 해결

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
