### PR TITLE
feat: 로그아웃 시 사용자 데이터 초기화 및 비로그인 상태 기능 제한 처리 (#348)

### DIFF
--- a/src/features/auth/store/authstore.ts
+++ b/src/features/auth/store/authstore.ts
@@ -1,61 +1,75 @@
 import { authLogin, authSignup, authLogout, authRefreshToken } from '@/features/auth';
 import type { SignupFormData } from '@/features/auth';
+import { useFavoriteStore } from '@/features/favorite';
+import { useRewardStore } from '@/features/reward/store';
+import type { NavigateFunction } from 'react-router-dom';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 
 interface AuthState {
-  accessToken: string | null;
-  refreshToken: string | null;
+  access: string | null;
+  refresh: string | null;
   user: any | null;
   setToken: (accessToken: string) => void;
   setUser: (user: any) => void;
   signup: (data: SignupFormData) => Promise<void>;
   login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
-  refresh: () => Promise<void>;
+  logout: (navigate: NavigateFunction) => void;
+  refreshToken: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      accessToken: null,
-      refreshToken: null,
-      user: null,
-      setToken: (accessToken) => set({ accessToken }),
-      setUser: (user) => set({ user }),
-      signup: async (data) => {
-        await authSignup({
-          email: data.email,
-          password: data.password,
-          username: data.username,
-          nickname: data.nickname,
-          phone_number: data.phone,
-        });
-        await get().login(data.email, data.password);
-      },
-      login: async (email, password) => {
-        const res = await authLogin({ email, password });
-        const { accessToken, refreshToken, user } = res.data;
-        set({ accessToken, refreshToken, user });
-      },
-      logout: async () => {
-        await authLogout();
-        set({ accessToken: null, refreshToken: null, user: null });
-      },
-      refresh: async () => {
-        const { refreshToken } = get();
-        if (!refreshToken) return;
-        const res = await authRefreshToken({ refreshToken });
-        set({ accessToken: res.data.accessToken });
-      },
-    }),
-    {
-      name: 'auth-storage',
-      partialize: (state) => ({
-        accessToken: state.accessToken,
-        refreshToken: state.refreshToken,
-        user: state.user,
+  devtools(
+    persist(
+      (set, get) => ({
+        access: null,
+        refresh: null,
+        user: null,
+        setToken: (access) => set({ access }),
+        setUser: (user) => set({ user }),
+        signup: async (data) => {
+          await authSignup({
+            email: data.email,
+            password: data.password,
+            username: data.username,
+            nickname: data.nickname,
+            phone_number: data.phone,
+          });
+          await get().login(data.email, data.password);
+        },
+        login: async (email, password) => {
+          const res = await authLogin({ email, password });
+          const { access, refresh, user } = res.data;
+          console.log('로그인 성공, 새로운 상태 설정:', { access, user });
+          set({ access, refresh, user });
+        },
+        logout: async (navigate) => {
+          try {
+            await authLogout();
+          } catch (error) {
+            console.error('로그아웃 API 호출 실패:', error);
+          } finally {
+            set({ access: null, refresh: null, user: null });
+            useFavoriteStore.getState().reset();
+            useRewardStore.getState().resetReward();
+            navigate('/');
+          }
+        },
+        refreshToken: async () => {
+          const { refresh } = get();
+          if (!refresh) return;
+          const res = await authRefreshToken({ refreshToken: refresh });
+          set({ access: res.data.access });
+        },
       }),
-    }
+      {
+        name: 'auth-storage',
+        partialize: (state) => ({
+          access: state.access,
+          refresh: state.refresh,
+          user: state.user,
+        }),
+      }
+    )
   )
 );

--- a/src/features/favorite/FavoriteIcon.tsx
+++ b/src/features/favorite/FavoriteIcon.tsx
@@ -1,6 +1,8 @@
 import type { ProductCardType } from '@/types';
-import { useFavoriteStore } from './store';
+import { useFavoriteStore } from '@/features/favorite';
 import { EmptyHeartIcon, FilledHeartIcon } from '@/components/icon';
+import { useAuthStore } from '@/features/auth';
+import { useModalStore } from '@/store';
 
 interface FavoriteIconProps {
   product: ProductCardType;
@@ -9,12 +11,21 @@ interface FavoriteIconProps {
 
 export function FavoriteIcon({ product, className }: FavoriteIconProps) {
   const { favoriteProducts, toggleFavorite } = useFavoriteStore();
+  const { access } = useAuthStore();
+  const { openModal } = useModalStore();
+
   const isFavorited = favoriteProducts.some((p) => p.id === product.id);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
-    toggleFavorite(product);
+
+    if (!access) {
+      alert('로그인이 필요한 기능입니다.');
+      openModal('login');
+    } else {
+      toggleFavorite(product);
+    }
   };
 
   return (

--- a/src/features/favorite/store/favoritestore.ts
+++ b/src/features/favorite/store/favoritestore.ts
@@ -5,18 +5,24 @@ import { persist } from 'zustand/middleware';
 type FavoriteState = {
   favoriteProducts: ProductCardType[];
   toggleFavorite: (product: ProductCardType) => void;
+  reset: () => void;
+};
+
+const initialState = {
+  favoriteProducts: [],
 };
 
 export const useFavoriteStore = create<FavoriteState>()(
   persist(
     (set) => ({
-      favoriteProducts: [],
+      ...initialState,
       toggleFavorite: (product) =>
         set((state) => ({
           favoriteProducts: state.favoriteProducts.some((p) => p.id === product.id)
             ? state.favoriteProducts.filter((p) => p.id !== product.id)
             : [...state.favoriteProducts, product],
         })),
+      reset: () => set(initialState),
     }),
     {
       name: 'favorite-storage',

--- a/src/features/mypage/api/useChangePasswordMutation.ts
+++ b/src/features/mypage/api/useChangePasswordMutation.ts
@@ -5,18 +5,17 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 export const useChangePasswordMutation = () => {
-  const { logout, accessToken } = useAuthStore();
+  const { logout, access } = useAuthStore();
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: async ({ password }: { password: string }) => {
-      if (!accessToken) throw new Error('No access token');
+      if (!access) throw new Error('No access token');
       const res = await backendAPI.patch('/users/me', { password });
       return res.data;
     },
     onSuccess: () => {
-      logout();
-      navigate('/');
+      logout(navigate);
     },
   });
 };

--- a/src/features/mypage/api/useUserQuery.ts
+++ b/src/features/mypage/api/useUserQuery.ts
@@ -53,7 +53,7 @@ export const useUserMutation = () => {
     },
     onSuccess: () => {
       alert('비밀번호가 변경되었습니다. 다시 로그인 해주세요.');
-      logout();
+      logout(navigate);
       navigate('/login');
     },
     onError: (error) => {
@@ -70,7 +70,7 @@ export const useUserMutation = () => {
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: ['User'] });
       alert('회원 탈퇴가 완료되었습니다. 그동안 OBE-STORE를 이용해 주셔서 감사합니다.');
-      logout();
+      logout(navigate);
       navigate('/');
     },
     onError: (error) => {

--- a/src/features/mypage/components/MypageNav.tsx
+++ b/src/features/mypage/components/MypageNav.tsx
@@ -1,14 +1,20 @@
 import { useAuthStore } from '@/features/auth';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { IoIosArrowForward } from 'react-icons/io';
 
 export function MypageNav() {
   const { logout } = useAuthStore();
+  const navigate = useNavigate();
   const location = useLocation();
   const isOrderActive = () => {
     const path = location.pathname;
     return path.startsWith('/users/orderinfo') || path.startsWith('/users/orderdetail');
   };
+
+  const handleLogout = async () => {
+    await logout(navigate);
+  };
+
   return (
     <div className='m-4 flex w-60 flex-col gap-4 lg:m-8 lg:gap-8'>
       <h2 className='flex text-2xl font-semibold'>MYPAGE</h2>
@@ -53,7 +59,7 @@ export function MypageNav() {
 
         <li>
           <button
-            onClick={logout}
+            onClick={handleLogout}
             className='text-primary-500-70 cursor-pointer font-bold lg:text-lg'
           >
             로그아웃


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
로그아웃 시 사용자 데이터 초기화 및 비로그인 상태 기능 제한 처리

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #348 

## 🧩 작업 내용 (주요 변경사항)
- 로그아웃 시 마이페이지 관련 상태 전부 초기화 후 홈으로 자동 리다이렉트
- 찜 기능을 로그인된 사용자만 사용할 수 있도록 제한

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
