### PR TITLE
fix: 검색 네비게이션 로직으로 상품 상세페이지 진입 불가 문제 수정 (#354)

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,8 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import { Footer, Header } from '@/components/layout';
 import { GlobalModalManager } from '@/features/auth';
+import { useSearchNavigation } from '@/features/search';
 
 export function RootLayout() {
+  useSearchNavigation();
   return (
     <div className='flex min-h-screen w-full flex-col items-center'>
       <Header />

--- a/src/features/product/hooks/useProductsQuery.ts
+++ b/src/features/product/hooks/useProductsQuery.ts
@@ -29,7 +29,6 @@ export function useProductsQuery({
       if (sortOption) params.ordering = sortOption;
 
       const res = await backendAPI.get(`/products`, { params });
-      console.log('🔥 sending params: ', params);
       return res.data ?? [];
     },
   });

--- a/src/features/search/SearchModal.tsx
+++ b/src/features/search/SearchModal.tsx
@@ -1,16 +1,24 @@
-import { useSearchNavigation, useSearchStore } from '@/features/search';
-import type { MouseEvent } from 'react';
+import { useSearchStore } from '@/features/search';
+import { type MouseEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { SearchIcon } from '@/components/icon';
 
 export function SearchModal() {
-  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal } = useSearchStore();
-  useSearchNavigation();
+  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal, resetSearch } =
+    useSearchStore();
+  const navigate = useNavigate();
+
+  const handleClose = () => {
+    resetSearch();
+    closeSearchModal();
+    navigate('/products', { replace: true });
+  };
 
   if (!isOpenSearchModal) return null;
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
-      closeSearchModal();
+      handleClose();
     }
   };
 
@@ -31,12 +39,7 @@ export function SearchModal() {
             value={searchTerm}
             autoFocus
           />
-          <button
-            onClick={() => {
-              closeSearchModal();
-            }}
-            className='text-primary-700 ml-4 text-2xl font-black'
-          >
+          <button onClick={handleClose} className='text-primary-700 ml-4 text-2xl font-black'>
             ✕
           </button>
         </div>

--- a/src/features/search/hooks/useSearchNavigation.ts
+++ b/src/features/search/hooks/useSearchNavigation.ts
@@ -8,9 +8,20 @@ export function useSearchNavigation() {
   const location = useLocation();
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
 
+  const isDetailPage = /^\/products\/[^/]+$/.test(location.pathname);
+
   useEffect(() => {
-    if (debouncedSearchTerm && location.search !== `?q=${debouncedSearchTerm}`) {
+    if (isDetailPage) return;
+
+    const currentQ = new URLSearchParams(location.search).get('q') ?? '';
+
+    if (!debouncedSearchTerm && currentQ) {
+      navigate('/products', { replace: true });
+      return;
+    }
+
+    if (debouncedSearchTerm && currentQ !== debouncedSearchTerm) {
       navigate(`/products?q=${debouncedSearchTerm}`);
     }
-  }, [debouncedSearchTerm, navigate, location.search]);
+  }, [debouncedSearchTerm, navigate, location.pathname, location.search]);
 }

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,10 +1,18 @@
 import { ErrorMessage, Spinner } from '@/components/ui';
 import { ProductDetail, useProductDetailQuery } from '@/features/product';
+import { useSearchStore } from '@/features/search';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 export function ProductDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { product, productLoading, productError } = useProductDetailQuery(id!);
+
+  const { resetSearch } = useSearchStore();
+
+  useEffect(() => {
+    resetSearch();
+  }, []);
 
   if (productLoading) return <Spinner />;
   if (productError) return <ErrorMessage message='상품 정보를 불러오지 못했습니다.' />;

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -1,14 +1,20 @@
 import { ProductGrid, ProductSort, useProductsQuery } from '@/features/product';
 import { ErrorMessage, Spinner } from '@/components/ui';
 import { useSearchStore } from '@/features/search';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export function ProductsPage() {
-  const { searchTerm } = useSearchStore();
   const [searchParams] = useSearchParams();
+  const query = searchParams.get('q') ?? '';
+  const { searchTerm, setSearchTerm, isOpenSearchModal } = useSearchStore();
   const category = searchParams.get('category') ?? undefined;
   const [sortOption, setSortOption] = useState('');
+
+  useEffect(() => {
+    if (isOpenSearchModal) return;
+    if (query !== searchTerm) setSearchTerm(query);
+  }, [query, searchTerm, setSearchTerm]);
 
   const {
     data: products,


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
검색 모달·URL 연동 로직 때문에 상세페이지 진입이 막히고 검색어 초기화도 정상적으로 동작하지 않던 문제 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #354 

## 🧩 작업 내용 (주요 변경사항)
- `useSearchNavigation` 로직 개선  
  - 검색어(debounced)와 URL `q` 파라미터를 안정적으로 동기화
  - 상세페이지(`/products/:id`) 진입 시 불필요한 리다이렉트 발생하던 문제 방지
- `SearchModal`에서 `resetSearch()` 동작하지 않던 부분 해결
- `ProductsPage`에서 검색어 동기화 로직 보완
- 상세페이지 진입 시 검색 상태 초기화 (`ProductDetailPage`)
- 레이아웃에서 검색 네비게이션 훅을 안정적으로 동작하도록 구조 정리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
