### PR TITLE
chore: access 토큰을 기존 쿠키 방식에서 헤더로 변경, refresh는 쿠키로 처리 (#357)

### DIFF
--- a/src/api/backendAPI.ts
+++ b/src/api/backendAPI.ts
@@ -3,7 +3,6 @@ import { API_ENDPOINTS, useAuthStore } from '@/features/auth';
 
 export const backendAPI = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  withCredentials: true,
 });
 
 backendAPI.interceptors.request.use(
@@ -25,12 +24,12 @@ backendAPI.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refresh = useAuthStore.getState().refresh;
-        if (!refresh) throw new Error('no refresh token');
         const res = await axios.post(
           `${backendAPI.defaults.baseURL}${API_ENDPOINTS.REFRESH_TOKEN}`,
-          { refresh }
+          {},
+          { withCredentials: true }
         );
+
         const newAccessToken = res.data?.access;
         if (newAccessToken) {
           useAuthStore.getState().setToken(newAccessToken);
@@ -39,9 +38,8 @@ backendAPI.interceptors.response.use(
         }
       } catch (err) {
         console.error('Token refresh failed: ', err);
-        useAuthStore.getState().logout((to) => {
-          const target = typeof to === 'string' ? to : '/';
-          window.location.href = target;
+        useAuthStore.getState().logout(() => {
+          window.location.href = '/';
         });
       }
     }

--- a/src/features/auth/api/authAPI.ts
+++ b/src/features/auth/api/authAPI.ts
@@ -1,8 +1,16 @@
 import { backendAPI } from '@/api';
-import { API_ENDPOINTS } from '@/features/auth';
+import { API_ENDPOINTS, useAuthStore } from '@/features/auth';
 
-export const authLogin = (data: { email: string; password: string }) =>
-  backendAPI.post(API_ENDPOINTS.LOGIN, data);
+export const authLogin = async (data: { email: string; password: string }) => {
+  const res = await backendAPI.post(API_ENDPOINTS.LOGIN, data);
+  const { access, user } = res.data;
+
+  const store = useAuthStore.getState();
+  store.setToken(access);
+  store.setUser(user);
+
+  return res.data;
+};
 
 export const authSignup = (data: {
   email: string;
@@ -13,9 +21,6 @@ export const authSignup = (data: {
 }) => backendAPI.post(API_ENDPOINTS.SIGNUP, data);
 
 export const authLogout = () => backendAPI.post(API_ENDPOINTS.LOGOUT);
-
-export const authRefreshToken = (data: { refreshToken: string }) =>
-  backendAPI.post(API_ENDPOINTS.REFRESH_TOKEN, data);
 
 export const checkEmail = async (email: string) => {
   const res = await backendAPI.get(API_ENDPOINTS.EMAIL_CHECK, {

--- a/src/features/auth/store/authstore.ts
+++ b/src/features/auth/store/authstore.ts
@@ -1,4 +1,4 @@
-import { authLogin, authSignup, authLogout, authRefreshToken } from '@/features/auth';
+import { authLogin, authSignup, authLogout } from '@/features/auth';
 import type { SignupFormData } from '@/features/auth';
 import { useFavoriteStore } from '@/features/favorite';
 import { useRewardStore } from '@/features/reward/store';
@@ -8,14 +8,12 @@ import { devtools, persist } from 'zustand/middleware';
 
 interface AuthState {
   access: string | null;
-  refresh: string | null;
   user: any | null;
-  setToken: (accessToken: string) => void;
+  setToken: (access: string) => void;
   setUser: (user: any) => void;
   signup: (data: SignupFormData) => Promise<void>;
   login: (email: string, password: string) => Promise<void>;
   logout: (navigate: NavigateFunction) => void;
-  refreshToken: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -23,7 +21,6 @@ export const useAuthStore = create<AuthState>()(
     persist(
       (set, get) => ({
         access: null,
-        refresh: null,
         user: null,
         setToken: (access) => set({ access }),
         setUser: (user) => set({ user }),
@@ -38,10 +35,8 @@ export const useAuthStore = create<AuthState>()(
           await get().login(data.email, data.password);
         },
         login: async (email, password) => {
-          const res = await authLogin({ email, password });
-          const { access, refresh, user } = res.data;
-          console.log('로그인 성공, 새로운 상태 설정:', { access, user });
-          set({ access, refresh, user });
+          const { access, user } = await authLogin({ email, password });
+          set({ access, user });
         },
         logout: async (navigate) => {
           try {
@@ -49,24 +44,17 @@ export const useAuthStore = create<AuthState>()(
           } catch (error) {
             console.error('로그아웃 API 호출 실패:', error);
           } finally {
-            set({ access: null, refresh: null, user: null });
+            set({ access: null, user: null });
             useFavoriteStore.getState().reset();
             useRewardStore.getState().resetReward();
             navigate('/');
           }
-        },
-        refreshToken: async () => {
-          const { refresh } = get();
-          if (!refresh) return;
-          const res = await authRefreshToken({ refreshToken: refresh });
-          set({ access: res.data.access });
         },
       }),
       {
         name: 'auth-storage',
         partialize: (state) => ({
           access: state.access,
-          refresh: state.refresh,
           user: state.user,
         }),
       }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #357

## 🧩 작업 내용 (주요 변경사항)
- 기존 쿠키 기반 로그인에서 `access`를 헤더로 옮기고 `refresh`는 쿠키로 처리
- `refresh` 관련 코드 제거 `authstore`와 `authAPI` 파일에서 제거

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
