### PR TITLE
fix: 네이버 로그인 플로우 정상화 및 access 토큰 네이밍 통일 (#359)

### DIFF
--- a/src/features/auth/api/endpoints.ts
+++ b/src/features/auth/api/endpoints.ts
@@ -3,6 +3,6 @@ export const API_ENDPOINTS = {
   LOGIN: '/auth/login',
   LOGOUT: '/auth/logout',
   REFRESH_TOKEN: '/token/refresh',
-  NAVER_LOGIN: '/auth/naver/login',
+  NAVER_LOGIN: '/auth/naver/callback',
   EMAIL_CHECK: '/users/email/exist',
 };

--- a/src/features/auth/components/AuthButton.tsx
+++ b/src/features/auth/components/AuthButton.tsx
@@ -3,10 +3,10 @@ import { useAuthStore } from '@/features/auth';
 import { useModalStore } from '@/store';
 
 export function AuthButton() {
-  const { accessToken } = useAuthStore();
+  const { access } = useAuthStore();
   const { openModal } = useModalStore();
 
-  if (accessToken) return null;
+  if (access) return null;
 
   return (
     <ButtonBase onClick={() => openModal('login')} className='hidden lg:flex' variant='gnb'>

--- a/src/features/auth/components/NaverLoginButton.tsx
+++ b/src/features/auth/components/NaverLoginButton.tsx
@@ -3,7 +3,7 @@ import { naverIcon } from '@/assets';
 import { API_ENDPOINTS } from '../api';
 
 export function NaverLoginButton() {
-  const NAVER_LOGIN_URL = `${import.meta.env.VITE_API_URL}${API_ENDPOINTS.NAVER_LOGIN}`;
+  const NAVER_LOGIN_URL = `${import.meta.env.VITE_FRONT_URL}${API_ENDPOINTS.NAVER_LOGIN}`;
 
   const handleLogin = () => {
     window.location.href = NAVER_LOGIN_URL;

--- a/src/pages/CallbackPage.tsx
+++ b/src/pages/CallbackPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/features/auth';
-import axios from 'axios';
 
 export function CallbackPage() {
   const navigate = useNavigate();
@@ -10,30 +9,20 @@ export function CallbackPage() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const code = params.get('code');
-    const state = params.get('state');
+    const access = params.get('access');
+    const user = params.get('user');
 
-    if (!code || !state) {
-      alert('로그인 실패');
-      navigate('/auth/login');
+    if (!access || !user) {
+      alert('로그인에 실패했습니다. 다시 시도해주세요.');
+      navigate('/');
       return;
     }
 
-    axios
-      .get(`${import.meta.env.VITE_API_URL}/auth/naver/callback`, {
-        params: { code, state },
-        withCredentials: true,
-      })
-      .then((res) => {
-        const { accessToken, user } = res.data;
-        setToken(accessToken);
-        setUser(user);
-        navigate('/');
-      })
-      .catch(() => {
-        navigate('/login');
-      });
+    setToken(access);
+    if (user) setUser(JSON.parse(user));
+    alert('로그인 완료!');
+    navigate('/');
   }, []);
 
-  return <p>네이버 로그인 처리 중...</p>;
+  return null;
 }

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -3,7 +3,7 @@
 // import { Outlet } from 'react-router-dom';
 
 // export function ProtectedRoute() {
-//   const isLoggedIn = useAuthStore((state) => !!state.accessToken);
+//   const isLoggedIn = useAuthStore((state) => !!state.access);
 //   const openAuthModal = useAuthStore((state) => state.openAuthModal);
 
 //   useEffect(() => {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import {
   AboutPage,
+  CallbackPage,
   CartPage,
   FavoritesPage,
   MainPage,
@@ -28,6 +29,7 @@ export function Router() {
           <Route element={<RootLayout />}>
             <Route path='/' element={<MainPage />} />
             <Route path='about' element={<AboutPage />} />
+            <Route path='/auth/naver/callback' element={<CallbackPage />} />
             <Route path='/products' element={<ProductsPage />} />
             <Route path='/products/:id' element={<ProductDetailPage />} />
             <Route path='/order/order' element={<OrderPage />} />


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
네이버 로그인 플로우 정상화 및 access 토큰 네이밍 통일

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #359 

## 🧩 작업 내용 (주요 변경사항)
- `accessToken` → `access` 네이밍 통일
- `CallbackPage` 콜백 처리 개선
- `NaverLoginButton` / `AuthButton` 토큰 처리 방식 수정
- `ProtectedRoute` `access` 기반 인증 로직 수정
- `Router` 콜백 경로 정리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
