### PR TITLE
fix: ProductCard에 할인 가격 안 뜨는 문제 해결 (#365)

### DIFF
--- a/src/features/product/ProductCard.tsx
+++ b/src/features/product/ProductCard.tsx
@@ -26,7 +26,16 @@ export function ProductCard({ product }: ProductCardProps) {
           <h2>{product.brand_name}</h2>
           <h3 className='font-bold'>{product.product_name}</h3>
           <div className='flex items-center justify-between pr-px'>
-            <p className='font-bold'>₩{Number(product.product_value).toLocaleString('ko-KR')}</p>
+            {Number(String(product.discount_rate) !== '0.00') ? (
+              <div className='flex flex-col'>
+                <p className='text-primary-500-70 text-[10px] line-through'>
+                  ₩{Number(product.product_value).toLocaleString('ko-KR')}
+                </p>
+                <p className='font-bold'>₩{Number(product.dc_value).toLocaleString('ko-KR')}</p>
+              </div>
+            ) : (
+              <p className='font-bold'>₩{Number(product.product_value).toLocaleString('ko-KR')}</p>
+            )}
             <ReviewRating initialValue={Number(product.product_rating)} readOnly size={16} />
           </div>
         </div>

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -21,7 +21,13 @@ export interface ProductType {
 export interface ProductCardType
   extends Pick<
     ProductType,
-    'id' | 'product_name' | 'brand_name' | 'product_value' | 'dc_value' | 'product_rating'
+    | 'id'
+    | 'product_name'
+    | 'brand_name'
+    | 'product_value'
+    | 'discount_rate'
+    | 'dc_value'
+    | 'product_rating'
   > {
   product_image: { product_card_image: string }[];
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
할인 가격 표시 로직 및 ProductCardType 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #365 

## 🧩 작업 내용 (주요 변경사항)
- `ProductCard`에 `discount_rate` 조건문 추가
- 정상가/할인가 UI 표시 로직 보완
- `ProductCardType`에 `discount_rate` 필드 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
