### PR TITLE
fix: 검색 연동으로 인해 페이지 이동이 차단되는 문제 및 검색 UX 개선 (#368)

### DIFF
--- a/src/features/search/SearchModal.tsx
+++ b/src/features/search/SearchModal.tsx
@@ -1,31 +1,34 @@
 import { useSearchStore } from '@/features/search';
-import { type MouseEvent } from 'react';
+import { type KeyboardEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SearchIcon } from '@/components/icon';
 
 export function SearchModal() {
-  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal, resetSearch } =
-    useSearchStore();
+  const { searchTerm, setSearchTerm, isOpenSearchModal, closeSearchModal } = useSearchStore();
   const navigate = useNavigate();
 
   const handleClose = () => {
-    resetSearch();
     closeSearchModal();
-    navigate('/products', { replace: true });
+  };
+
+  const handleSearch = () => {
+    navigate(`products?q=${searchTerm}`);
+    handleClose();
+    alert('검색어가 적용되었습니다');
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
   };
 
   if (!isOpenSearchModal) return null;
 
-  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      handleClose();
-    }
-  };
-
   return (
     <div
       className='bg-primary-700/50 fixed inset-0 z-50 flex items-start justify-center backdrop-blur-xs'
-      onClick={handleBackdropClick}
+      onClick={(e) => e.target === e.currentTarget && handleClose()}
     >
       <div className='rounded-bg w-full bg-white p-4'>
         <div className='relative flex items-center'>
@@ -36,6 +39,7 @@ export function SearchModal() {
             type='search'
             className='input ml-4 flex h-10 grow'
             onChange={(e) => setSearchTerm(e.target.value)}
+            onKeyDown={handleKeyDown}
             value={searchTerm}
             autoFocus
           />

--- a/src/features/search/hooks/useSearchNavigation.ts
+++ b/src/features/search/hooks/useSearchNavigation.ts
@@ -3,15 +3,13 @@ import { useDebounce, useSearchStore } from '@/features/search';
 import { useEffect } from 'react';
 
 export function useSearchNavigation() {
-  const { searchTerm } = useSearchStore();
+  const { searchTerm, isOpenSearchModal } = useSearchStore();
   const navigate = useNavigate();
   const location = useLocation();
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
 
-  const isDetailPage = /^\/products\/[^/]+$/.test(location.pathname);
-
   useEffect(() => {
-    if (isDetailPage) return;
+    if (!isOpenSearchModal) return;
 
     const currentQ = new URLSearchParams(location.search).get('q') ?? '';
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
검색창에 엔터 치면 창 닫히게 하고 검색 모달이 닫혀있으면 페이지 이동에 제한이 없도록 설정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #368 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
