### PR TITLE
fix: 헤더 모바일 메뉴와 정렬 드롭다운이 같이 열리는 문제 해결 (#416)

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -6,13 +6,13 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useToggleStore } from '@/store';
 
 export function Header() {
-  const { isOpen, toggleMenu } = useToggleStore();
+  const { isMenuOpen, toggleMenu } = useToggleStore();
   return (
     <header className='fixed top-0 z-100 flex w-full justify-center bg-white'>
       <div className='bg-primary-100 container-1200 flex h-16 grow items-center justify-between px-8'>
         <div className='flex gap-8'>
           <button className='md:hidden' onClick={toggleMenu} aria-label='메뉴 열기'>
-            {isOpen ? <div className='pt-0.5 text-xl font-black'>✕</div> : <MenuIcon />}
+            {isMenuOpen ? <div className='pt-0.5 text-xl font-black'>✕</div> : <MenuIcon />}
           </button>
           <HeaderLogoIcon width={48} />
           <HeaderNav />
@@ -24,7 +24,7 @@ export function Header() {
         </div>
       </div>
       <AnimatePresence>
-        {isOpen && (
+        {isMenuOpen && (
           <motion.nav
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -6,13 +6,13 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useToggleStore } from '@/store';
 
 export function Header() {
-  const { isMenuOpen, toggleMenu } = useToggleStore();
+  const { isOpen, toggleMenu } = useToggleStore();
   return (
     <header className='fixed top-0 z-100 flex w-full justify-center bg-white'>
       <div className='bg-primary-100 container-1200 flex h-16 grow items-center justify-between px-8'>
         <div className='flex gap-8'>
           <button className='md:hidden' onClick={toggleMenu} aria-label='메뉴 열기'>
-            {isMenuOpen ? <div className='pt-0.5 text-xl font-black'>✕</div> : <MenuIcon />}
+            {isOpen ? <div className='pt-0.5 text-xl font-black'>✕</div> : <MenuIcon />}
           </button>
           <HeaderLogoIcon width={48} />
           <HeaderNav />
@@ -24,7 +24,7 @@ export function Header() {
         </div>
       </div>
       <AnimatePresence>
-        {isMenuOpen && (
+        {isOpen && (
           <motion.nav
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}

--- a/src/features/product/ProductSort.tsx
+++ b/src/features/product/ProductSort.tsx
@@ -11,7 +11,7 @@ interface ProductSortProps {
 }
 
 export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
-  const { isOpen, toggleSort, closeSort } = useToggleStore();
+  const { isSortOpen, toggleSort, closeSort } = useToggleStore();
 
   const selectedOptionLabel =
     SORT_OPTIONS.find((option) => option.value === selectedOption)?.label || SORT_OPTIONS[0].label;
@@ -26,7 +26,7 @@ export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
         <RiArrowDropDownLine size={20} />
       </button>
       <AnimatePresence>
-        {isOpen && (
+        {isSortOpen && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/features/product/ProductSort.tsx
+++ b/src/features/product/ProductSort.tsx
@@ -2,20 +2,19 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { RiArrowDropDownLine } from 'react-icons/ri';
 import { SORT_OPTIONS } from '@/constants';
 import { useToggleStore } from '@/store';
-import { useProductFilterStore } from '@/features/product';
 
 type SortOptionType = string;
 
 interface ProductSortProps {
   selectedOption: SortOptionType;
+  onChange: (value: SortOptionType) => void;
 }
 
-export function ProductSort({ selectedOption }: ProductSortProps) {
-  const { isSortOpen, toggleSort, closeSort } = useToggleStore();
-  const { sort, setSort } = useProductFilterStore();
+export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
+  const { isOpen, toggleSort, closeSort } = useToggleStore();
 
   const selectedOptionLabel =
-    SORT_OPTIONS.find((option) => option.value === sort)?.label || SORT_OPTIONS[0].label;
+    SORT_OPTIONS.find((option) => option.value === selectedOption)?.label || SORT_OPTIONS[0].label;
 
   return (
     <div className='relative inline-block w-40'>
@@ -27,7 +26,7 @@ export function ProductSort({ selectedOption }: ProductSortProps) {
         <RiArrowDropDownLine size={20} />
       </button>
       <AnimatePresence>
-        {isSortOpen && (
+        {isOpen && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -41,7 +40,7 @@ export function ProductSort({ selectedOption }: ProductSortProps) {
                   selectedOption === option.value ? 'text-primary-700 font-bold' : ''
                 }`}
                 onClick={() => {
-                  setSort(option.value);
+                  onChange(option.value);
                   closeSort();
                 }}
               >

--- a/src/features/product/ProductSort.tsx
+++ b/src/features/product/ProductSort.tsx
@@ -2,19 +2,20 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { RiArrowDropDownLine } from 'react-icons/ri';
 import { SORT_OPTIONS } from '@/constants';
 import { useToggleStore } from '@/store';
+import { useProductFilterStore } from '@/features/product';
 
 type SortOptionType = string;
 
 interface ProductSortProps {
   selectedOption: SortOptionType;
-  onChange: (value: SortOptionType) => void;
 }
 
-export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
-  const { isOpen, toggleSort, closeSort } = useToggleStore();
+export function ProductSort({ selectedOption }: ProductSortProps) {
+  const { isSortOpen, toggleSort, closeSort } = useToggleStore();
+  const { sort, setSort } = useProductFilterStore();
 
   const selectedOptionLabel =
-    SORT_OPTIONS.find((option) => option.value === selectedOption)?.label || SORT_OPTIONS[0].label;
+    SORT_OPTIONS.find((option) => option.value === sort)?.label || SORT_OPTIONS[0].label;
 
   return (
     <div className='relative inline-block w-40'>
@@ -26,7 +27,7 @@ export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
         <RiArrowDropDownLine size={20} />
       </button>
       <AnimatePresence>
-        {isOpen && (
+        {isSortOpen && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -40,7 +41,7 @@ export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
                   selectedOption === option.value ? 'text-primary-700 font-bold' : ''
                 }`}
                 onClick={() => {
-                  onChange(option.value);
+                  setSort(option.value);
                   closeSort();
                 }}
               >

--- a/src/store/useToggleStore.ts
+++ b/src/store/useToggleStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 
 type ToggleState = {
-  isOpen: boolean;
+  isMenuOpen: boolean;
+  isSortOpen: boolean;
   openMenu: () => void;
   closeMenu: () => void;
   toggleMenu: () => void;
@@ -11,11 +12,12 @@ type ToggleState = {
 };
 
 export const useToggleStore = create<ToggleState>((set) => ({
-  isOpen: false,
-  openMenu: () => set({ isOpen: true }),
-  closeMenu: () => set({ isOpen: false }),
-  toggleMenu: () => set((state) => ({ isOpen: !state.isOpen })),
-  openSort: () => set({ isOpen: true }),
-  closeSort: () => set({ isOpen: false }),
-  toggleSort: () => set((state) => ({ isOpen: !state.isOpen })),
+  isMenuOpen: false,
+  isSortOpen: false,
+  openMenu: () => set({ isMenuOpen: true }),
+  closeMenu: () => set({ isMenuOpen: false }),
+  toggleMenu: () => set((state) => ({ isMenuOpen: !state.isMenuOpen })),
+  openSort: () => set({ isSortOpen: true }),
+  closeSort: () => set({ isSortOpen: false }),
+  toggleSort: () => set((state) => ({ isSortOpen: !state.isSortOpen })),
 }));

--- a/src/store/useToggleStore.ts
+++ b/src/store/useToggleStore.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand';
 
 type ToggleState = {
-  isMenuOpen: boolean;
-  isSortOpen: boolean;
+  isOpen: boolean;
   openMenu: () => void;
   closeMenu: () => void;
   toggleMenu: () => void;
@@ -12,12 +11,11 @@ type ToggleState = {
 };
 
 export const useToggleStore = create<ToggleState>((set) => ({
-  isMenuOpen: false,
-  isSortOpen: false,
-  openMenu: () => set({ isMenuOpen: true }),
-  closeMenu: () => set({ isMenuOpen: false }),
-  toggleMenu: () => set((state) => ({ isMenuOpen: !state.isMenuOpen })),
-  openSort: () => set({ isSortOpen: true }),
-  closeSort: () => set({ isSortOpen: false }),
-  toggleSort: () => set((state) => ({ isSortOpen: !state.isSortOpen })),
+  isOpen: false,
+  openMenu: () => set({ isOpen: true }),
+  closeMenu: () => set({ isOpen: false }),
+  toggleMenu: () => set((state) => ({ isOpen: !state.isOpen })),
+  openSort: () => set({ isOpen: true }),
+  closeSort: () => set({ isOpen: false }),
+  toggleSort: () => set((state) => ({ isOpen: !state.isOpen })),
 }));


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
헤더 모바일 메뉴와 정렬 드롭다운이 같이 열리는 문제 해결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #416 

## 🧩 작업 내용 (주요 변경사항)
- 두 컴포넌트가 공유하는 `isOpen`을 각각 `isMenuOpen`과 `isSortOpen`으로 분리
- 해당 컴포넌트들 수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
