### PR TITLE
fix: 상품 목록 정렬 상태가 페이지 이동 후 초기화되는 문제 수정 (#419)

### DIFF
--- a/src/features/product/ProductSort.tsx
+++ b/src/features/product/ProductSort.tsx
@@ -2,19 +2,20 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { RiArrowDropDownLine } from 'react-icons/ri';
 import { SORT_OPTIONS } from '@/constants';
 import { useToggleStore } from '@/store';
+import { useProductFilterStore } from '@/features/product';
 
 type SortOptionType = string;
 
 interface ProductSortProps {
   selectedOption: SortOptionType;
-  onChange: (value: SortOptionType) => void;
 }
 
-export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
+export function ProductSort({ selectedOption }: ProductSortProps) {
   const { isSortOpen, toggleSort, closeSort } = useToggleStore();
+  const { sort, setSort } = useProductFilterStore();
 
   const selectedOptionLabel =
-    SORT_OPTIONS.find((option) => option.value === selectedOption)?.label || SORT_OPTIONS[0].label;
+    SORT_OPTIONS.find((option) => option.value === sort)?.label || SORT_OPTIONS[0].label;
 
   return (
     <div className='relative inline-block w-40'>
@@ -40,7 +41,7 @@ export function ProductSort({ selectedOption, onChange }: ProductSortProps) {
                   selectedOption === option.value ? 'text-primary-700 font-bold' : ''
                 }`}
                 onClick={() => {
-                  onChange(option.value);
+                  setSort(option.value);
                   closeSort();
                 }}
               >

--- a/src/features/product/index.ts
+++ b/src/features/product/index.ts
@@ -6,3 +6,4 @@ export * from './ProductSection';
 export * from './ProductSort';
 export * from './ProductQnA';
 export * from './hooks';
+export * from './store';

--- a/src/features/product/store/index.ts
+++ b/src/features/product/store/index.ts
@@ -1,0 +1,1 @@
+export * from './productFilterStore';

--- a/src/features/product/store/productFilterStore.ts
+++ b/src/features/product/store/productFilterStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ProductFilterState {
+  sort: string;
+  setSort: (sort: string) => void;
+}
+
+export const useProductFilterStore = create<ProductFilterState>()(
+  persist(
+    (set) => ({
+      sort: '',
+      setSort: (sort) => set({ sort }),
+    }),
+    { name: 'product-filter' }
+  )
+);

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -33,7 +33,7 @@ export function ProductsPage() {
     <main className='bg-primary-100 p-4'>
       <div className='mb-4 flex items-center justify-between'>
         <h1 className='text-xl font-bold'>상품 목록</h1>
-        <ProductSort selectedOption={sortOption} onChange={setSortOption} />
+        <ProductSort selectedOption={sortOption} />
       </div>
       {products && products.length > 0 ? (
         <ProductGrid products={products} />


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
상품 목록 정렬 상태가 페이지 이동 후 초기화되는 문제를 전역 상태관리로 해결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->
Closes #419 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 빌드 및 실행 확인 완료
